### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This was an atempt to transform a design idea into code. Here's the inspiration 
 
 [Loading with Swift](https://dribbble.com/shots/1911260-Loading-with-Swift) 
 
-####Creativedash: <br>
+#### Creativedash: <br>
 <img src="https://d13yacurqjgara.cloudfront.net/users/107759/screenshots/1911260/loading.gif" alt="Dribble" width="280" style="max-width:100%;">
 
-####MessageBalloon: <br>
+#### MessageBalloon: <br>
 <img src="http://i.imgur.com/hbs7ABy.gif" alt="MessageBalloon" width="280" style="max-width:100%;">
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
